### PR TITLE
Adding type check to construct_mass_matrix

### DIFF
--- a/src/NetworkStructures.jl
+++ b/src/NetworkStructures.jl
@@ -293,8 +293,14 @@ function construct_mass_matrix(mmv_array, gs)
     else
         mass_matrix = sparse(1.0I,gs.dim_v, gs.dim_v)
         for (i, mm) in enumerate(mmv_array)
-            if mm != I
-                mass_matrix[gs.v_idx[i],gs.v_idx[i]] .= mm
+            if mm != I    
+                if mm isa Array{T, 1} where T
+                    for k in 1:length(mm)
+                        mass_matrix[gs.v_idx[i][k], gs.v_idx[i][k]] = mm[k]
+                    end
+                else
+                    mass_matrix[gs.v_idx[i],gs.v_idx[i]] .= mm
+                end
             end
         end
     end

--- a/src/NetworkStructures.jl
+++ b/src/NetworkStructures.jl
@@ -293,14 +293,14 @@ function construct_mass_matrix(mmv_array, gs)
     else
         mass_matrix = sparse(1.0I,gs.dim_v, gs.dim_v)
         for (i, mm) in enumerate(mmv_array)
-            if mm != I    
-                if mm isa Array{T, 1} where T
-                    for k in 1:length(mm)
-                        mass_matrix[gs.v_idx[i][k], gs.v_idx[i][k]] = mm[k]
-                    end
-                else
-                    mass_matrix[gs.v_idx[i],gs.v_idx[i]] .= mm
+            if ndims(mm) == 1
+                for k in 1:length(mm)
+                    mass_matrix[gs.v_idx[i][k], gs.v_idx[i][k]] = mm[k]
                 end
+            elseif ndims(mm) == 2
+                mass_matrix[gs.v_idx[i],gs.v_idx[i]] .= mm
+            else
+                error("The mass matrix needs to be a 2D matrix.")
             end
         end
     end

--- a/src/NetworkStructures.jl
+++ b/src/NetworkStructures.jl
@@ -297,7 +297,7 @@ function construct_mass_matrix(mmv_array, gs)
                 for k in 1:length(mm)
                     mass_matrix[gs.v_idx[i][k], gs.v_idx[i][k]] = mm[k]
                 end
-            elseif ndims(mm) == 2
+            elseif ndims(mm) == 2 # ndims(I) = 2
                 mass_matrix[gs.v_idx[i],gs.v_idx[i]] .= mm
             else
                 error("The mass matrix needs to be a 2D matrix.")


### PR DESCRIPTION
I suggest to capture the case of mass matrix arrays as the broadcast does not put the values of the array on the diagonal of the overall mass matrix. In fact, you end up with off-diagonal entries. 
We came across this problem in PD where the node mass matrix happens to be just an array in certain cases (I am going to change the behaviour to return `Diagonal` component mass matrices).